### PR TITLE
Add JFR event

### DIFF
--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -52,7 +52,7 @@
                   <shadedPattern>agent.net.bytebuddy</shadedPattern>
                 </relocation>
               </relocations>
-              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <createDependencyReducedPom>true</createDependencyReducedPom>
             </configuration>
           </execution>
         </executions>

--- a/agent/src/main/java/io/type/pollution/agent/TraceInstanceOf.java
+++ b/agent/src/main/java/io/type/pollution/agent/TraceInstanceOf.java
@@ -101,6 +101,13 @@ public class TraceInstanceOf {
             LAST_SEEN_INTERFACE_UPDATER.lazySet(this, interfaceClazz);
             if (lastSeen != null) {
                 updateTraceCount(interfaceClazz, trace);
+
+                TypeCheckThrashEvent event = new TypeCheckThrashEvent();
+                if (event.isEnabled()) {
+                    event.concreteClass = clazz.getName();
+                    event.interfaceClass = interfaceClazz.getName();
+                    event.commit();
+                }
             }
         }
     }
@@ -118,7 +125,7 @@ public class TraceInstanceOf {
         private static final AtomicLongFieldUpdater<TraceCounter> SAMPLING_TICK_UPDATER =
                 AtomicLongFieldUpdater.newUpdater(TraceCounter.class, "lastSamplingTick");
 
-        private final Class clazz;
+        final Class clazz;
         private volatile long lastSamplingTick = System.nanoTime();
         private final ConcurrentHashMap<Trace, TraceData> traces = new ConcurrentHashMap<>();
         private static final ThreadLocal<Trace> TRACE = ThreadLocal.withInitial(Trace::new);

--- a/agent/src/main/java/io/type/pollution/agent/TypeCheckThrashEvent.java
+++ b/agent/src/main/java/io/type/pollution/agent/TypeCheckThrashEvent.java
@@ -1,0 +1,27 @@
+package io.type.pollution.agent;
+
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Enabled;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+import jdk.jfr.StackTrace;
+
+@Name(TypeCheckThrashEvent.NAME)
+@Label("Type check cache thrashing")
+@Category("Type check")
+@Description("An interface type check is invalidating a previously cached type check result. If this happens often, it can lead to thrashing and contention of the cache field.")
+@StackTrace
+@Enabled(false)
+public class TypeCheckThrashEvent extends Event {
+    static final String NAME = "io.type.pollution.agent.TypeCheckThrashEvent";
+
+    @Label("Concrete type")
+    @Description("Concrete class of the object that was type checked (the thrashed cache field is stored in this class)")
+    public String concreteClass;
+
+    @Label("Interface type")
+    @Description("Interface that this object was checked against (this is the type that is stored in the thrashed cache field)")
+    public String interfaceClass;
+}


### PR DESCRIPTION
This PR adds a JFR event that is triggered whenever there is a "thrashing" event where the cached interface is changed. The event contains the concrete class, the interface class, and a stack trace. It is disabled by default so that there is no impact when JFR is not used.

Additionally:

- Add a check that a modified class' loader actually can access the TraceInstanceOf class. This is necessary because gradle test workers have a filtering classloader for internal code that does not include the agent, and any type check in that class loader would fail.
- Enable the dependency reduced pom to allow for proper publishing of the shaded jar to a maven repo.